### PR TITLE
Change `AddSingleton` to `AddScoped`

### DIFF
--- a/src/BreweryApi.Application/Extensions/DependencyInjection.cs
+++ b/src/BreweryApi.Application/Extensions/DependencyInjection.cs
@@ -8,7 +8,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection RegisterServices(this IServiceCollection services)
     {
-        services.AddSingleton<IBreweryService, BreweryService>();
+        services.AddScoped<IBreweryService, BreweryService>();
         return services;
     }
 }

--- a/src/BreweryApi.Infrastructure/Extensions/DependencyInjection.cs
+++ b/src/BreweryApi.Infrastructure/Extensions/DependencyInjection.cs
@@ -8,7 +8,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection RegisterServices(this IServiceCollection services)
     {
-        services.AddSingleton<IBreweryRepository, BreweryRepository>();
+        services.AddScoped<IBreweryRepository, BreweryRepository>();
         return services;
     }
 }


### PR DESCRIPTION
Later in the series there is a guide on adding Entity Framewore Core to the app. When we register the DbContext the app will fail to run. The app fails to run because DbContext is scoped by default.

If the Service & Repository are registered as Singleton then each time we load the code it will keep the same instance, whereas the DbContext requires a new instance.

Due to the 'parent' in this case being a Singleton the process will fail.